### PR TITLE
scrapping-8:  Deployment dev job can be triggered by a release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -60,7 +60,10 @@ jobs:
       github.ref == 'refs/heads/master' ||
       (github.event_name == 'pull_request' &&
        github.event.pull_request.merged == true &&
-       github.event.pull_request.base.ref == 'master')
+       github.event.pull_request.base.ref == 'master') ||
+       github.event_name == 'release'
+    max-attempts: 6
+    failure-action: retry
 
     steps:
       - name: Check out code
@@ -85,8 +88,10 @@ jobs:
 
   deploy_prod:
     runs-on: ubuntu-latest
-    needs: [install_dependencies, run_tests]
+    needs: [install_dependencies, run_tests, deploy_dev]
     if: github.event_name == 'release' && github.event.action == 'created'
+    max-attempts: 6
+    failure-action: retry
 
     steps:
       - name: Check out code


### PR DESCRIPTION


# Summary

- Deployment dev job can be triggered by a release
- Added the ability to retry a job for 5 times

<!-- Please include a summary of the change and which issue is fixed. Do not delete this section -->

# Tests

<!-- Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration. -->

N/A